### PR TITLE
Upgrade node fetch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,15 +25,8 @@
   ],
   "dependencies": {
     "protobufjs": "^7.2.4",
-    "snappyjs": "^0.6.1"
-  },
-  "peerDependencies": {
+    "snappyjs": "^0.6.1",
     "node-fetch": "^3.3.2"
-  },
-  "peerDependenciesMeta": {
-    "node-fetch": {
-      "optional": true
-    }
   },
   "devDependencies": {
     "protobufjs-cli": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "snappyjs": "^0.6.1"
   },
   "peerDependencies": {
-    "node-fetch": "^2.6.7"
+    "node-fetch": "^3.3.2"
   },
   "peerDependenciesMeta": {
     "node-fetch": {


### PR DESCRIPTION
Hey,

Current version of `nodefetch: 2.6.7` causes `DeprecationWarning` about module `punycode` being deprecated. Can you please consider bumping up the version?

Tested locally, warning is cleared.

Thank you